### PR TITLE
Item collection extents and thumbnails

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,13 +82,13 @@ async function addOverviewAssetForFeature (feature, layerGroup, crossOrigin, err
   if (isImageType(asset.type)) {
     const lyr = await imageOverlay(asset.href, [[feature.bbox[1], feature.bbox[0]], [feature.bbox[3], feature.bbox[2]]], crossOrigin);
     if (lyr === null) {
-      errorCallback()
+      if (errorCallback) errorCallback()
       return
     }
     layerGroup.addLayer(lyr)
     lyr.on('error', () => {
       layerGroup.removeLayer(lyr)
-      errorCallback()
+      if (errorCallback) errorCallback()
     })
   }
 }
@@ -98,13 +98,13 @@ async function addThumbnailAssetForFeature (feature, layerGroup, crossOrigin, er
   if (isImageType(asset.type)) { 
     const lyr = await imageOverlay(asset.href, [[feature.bbox[1], feature.bbox[0]], [feature.bbox[3], feature.bbox[2]]], crossOrigin);
     if (lyr === null) {
-      errorCallback()
+      if (errorCallback) errorCallback()
       return
     }
     layerGroup.addLayer(lyr)
     lyr.on('error', () => {
       layerGroup.removeLayer(lyr)
-      errorCallback()
+      if (errorCallback) errorCallback()
     })
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -197,6 +197,13 @@ const stacLayer = async (data, options = {}) => {
     // Item Collection aka GeoJSON Feature Collection where each Feature is a STAC Item
     // STAC API /items endpoint also returns a similar Feature Collection
     const lyr = L.geoJSON(data, options);
+
+    data.features.forEach(f => {
+      if (displayPreview && hasAsset(f.assets, "thumbnail") && isImageType(f.assets.thumbnail.type)) { 
+        const lyr = L.imageOverlay(f.assets.thumbnail.href, [[f.bbox[1], f.bbox[0]], [f.bbox[3], f.bbox[2]]])
+        layerGroup.addLayer(lyr)
+      }
+    })
     bindDataToClickEvent(lyr, e => {
       try {
         const { lat, lng } = e.latlng;

--- a/src/index.js
+++ b/src/index.js
@@ -77,10 +77,14 @@ function getDataType(data) {
   }
 }
 
-function addOverviewAssetForFeature (feature, layerGroup, errorCallback) {
+async function addOverviewAssetForFeature (feature, layerGroup, crossOrigin, errorCallback) {
   const { asset } = getOverviewAsset(feature.assets);
   if (isImageType(asset.type)) {
-    const lyr = L.imageOverlay(asset.href, [[feature.bbox[1], feature.bbox[0]], [feature.bbox[3], feature.bbox[2]]])
+    const lyr = await imageOverlay(asset.href, [[feature.bbox[1], feature.bbox[0]], [feature.bbox[3], feature.bbox[2]]], crossOrigin);
+    if (lyr === null) {
+      errorCallback()
+      return
+    }
     layerGroup.addLayer(lyr)
     lyr.on('error', () => {
       layerGroup.removeLayer(lyr)
@@ -89,10 +93,14 @@ function addOverviewAssetForFeature (feature, layerGroup, errorCallback) {
   }
 }
 
-function addThumbnailAssetForFeature (feature, layerGroup, errorCallback) {
+async function addThumbnailAssetForFeature (feature, layerGroup, crossOrigin, errorCallback) {
   const { asset } = findAsset(feature.assets, 'thumbnail');
   if (isImageType(asset.type)) { 
-    const lyr = L.imageOverlay(asset.href, [[feature.bbox[1], feature.bbox[0]], [feature.bbox[3], feature.bbox[2]]])
+    const lyr = await imageOverlay(asset.href, [[feature.bbox[1], feature.bbox[0]], [feature.bbox[3], feature.bbox[2]]], crossOrigin);
+    if (lyr === null) {
+      errorCallback()
+      return
+    }
     layerGroup.addLayer(lyr)
     lyr.on('error', () => {
       layerGroup.removeLayer(lyr)
@@ -227,15 +235,15 @@ const stacLayer = async (data, options = {}) => {
       if (displayPreview) {
         // If we've got a thumnail asset add it
         if (hasAsset(f.assets, "thumbnail")) { 
-          addThumbnailAssetForFeature(f, layerGroup, () => {
+          addThumbnailAssetForFeature(f, layerGroup, options.crossOrigin, () => {
             // If some reason it's broken try for an overview asset
             if (hasAsset(f.assets, "overview")) {
-              addOverviewAssetForFeature(f, layerGroup)
+              addOverviewAssetForFeature(f, layerGroup, options.crossOrigin)
             }
           })
         } else if (!hasAsset(f.assets, "thumbnail") && hasAsset(f.assets, "overview")) {
             // If we don't have a thumbail let's try for an overview asset
-            addOverviewAssetForFeature(f, layerGroup)
+            addOverviewAssetForFeature(f, layerGroup, options.crossOrigin)
       }
     }
 
@@ -322,13 +330,15 @@ const stacLayer = async (data, options = {}) => {
 
         if (isImageType(type)) {
           const overviewLayer = await imageOverlay(href, bounds, options.crossOrigin);
-          bindDataToClickEvent(overviewLayer, asset);
-          // there probably aren't eo:bands attached to an overview
-          // but we include this here just in case
-          layerGroup.stac = { assets: [{ key, asset }], bands: asset?.["eo:bands"] };
-          layerGroup.addLayer(overviewLayer);
-          addedImagery = true;
-          if (debugLevel >= 1) console.log("[stac-layer] succesfully added overview layer");
+          if (overviewLayer !== null) {
+            bindDataToClickEvent(overviewLayer, asset);
+            // there probably aren't eo:bands attached to an overview
+            // but we include this here just in case
+            layerGroup.stac = { assets: [{ key, asset }], bands: asset?.["eo:bands"] };
+            layerGroup.addLayer(overviewLayer);
+            addedImagery = true;
+            if (debugLevel >= 1) console.log("[stac-layer] succesfully added overview layer");            
+          }
         } else if (isAssetCOG(asset)) {
           if (preferTileLayer) {
             await addTileLayer({ asset, href, isCOG: true, isVisual: true, key });
@@ -367,10 +377,12 @@ const stacLayer = async (data, options = {}) => {
 
         if (isImageType(type)) {
           const thumbLayer = await imageOverlay(href, bounds, options.crossOrigin);
-          bindDataToClickEvent(thumbLayer, data);
-          layerGroup.addLayer(thumbLayer);
-          addedImagery = true;
-          if (debugLevel >= 1) console.log("[stac-layer] succesfully added thumbnail layer");
+          if (thumbLayer !== null) {
+            bindDataToClickEvent(thumbLayer, data);
+            layerGroup.addLayer(thumbLayer);
+            addedImagery = true;
+            if (debugLevel >= 1) console.log("[stac-layer] succesfully added thumbnail layer");            
+          }
         }
       } catch (error) {
         if (debugLevel >= 1)
@@ -388,10 +400,12 @@ const stacLayer = async (data, options = {}) => {
 
         if (isImageType(type)) {
           const previewLayer = await imageOverlay(href, bounds, options.crossOrigin);
-          bindDataToClickEvent(previewLayer, data);
-          layerGroup.addLayer(previewLayer);
-          addedImagery = true;
-          if (debugLevel >= 1) console.log("[stac-layer] succesfully added preview layer");
+          if (previewLayer !== null) {
+            bindDataToClickEvent(previewLayer, data);
+            layerGroup.addLayer(previewLayer);
+            addedImagery = true;
+            if (debugLevel >= 1) console.log("[stac-layer] succesfully added preview layer");            
+          }
         }
       } catch (error) {
         if (debugLevel >= 1)
@@ -550,9 +564,11 @@ const stacLayer = async (data, options = {}) => {
       }
 
       const lyr = await imageOverlay(href, bounds, options.crossOrigin);
-      bindDataToClickEvent(lyr);
-      layerGroup.addLayer(lyr);
-      fillOpacity = 0;
+      if (lyr !== null) {
+        bindDataToClickEvent(lyr);
+        layerGroup.addLayer(lyr);
+        fillOpacity = 0;
+      }
     } else if (MIME_TYPES.GEOTIFF.includes(type)) {
       const addTileLayer = async () => {
         try {

--- a/src/index.js
+++ b/src/index.js
@@ -224,10 +224,17 @@ const stacLayer = async (data, options = {}) => {
     data.features.forEach(f => {
 
       if (displayPreview) {
+        // If we've got a thumnail asset add it
         if (hasAsset(f.assets, "thumbnail")) { 
-          addThumbnailAssetForFeature(f, layerGroup, addOverviewAssetForFeature(f, layerGroup))
+          addThumbnailAssetForFeature(f, layerGroup, () => {
+            // If some reason it's broken try for an overview asset
+            if (hasAsset(f.assets, "overview")) {
+              addOverviewAssetForFeature(f, layerGroup)
+            }
+          })
         } else if (!hasAsset(f.assets, "thumbnail") && hasAsset(f.assets, "overview")) {
-          addOverviewAssetForFeature(f, layerGroup)
+            // If we don't have a thumbail let's try for an overview asset
+            addOverviewAssetForFeature(f, layerGroup)
       }
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,8 @@ import createGeoRasterLayer from "./utils/create-georaster-layer.js";
 const isJPG = type => !!type.match(/^image\/jpe?g/i);
 const isPNG = type => !!type.match(/^image\/png/i);
 const isImageType = type => isJPG(type) || isPNG(type);
-const isAssetCOG = asset => MIME_TYPES.COG.includes(asset.type) && typeof asset.href === 'string' && asset.href.length > 0;
+const isAssetCOG = asset =>
+  MIME_TYPES.COG.includes(asset.type) && typeof asset.href === "string" && asset.href.length > 0;
 
 const getOverviewAsset = assets => findAsset(assets, "overview");
 const hasAsset = (assets, key) => !!findAsset(assets, key);
@@ -77,35 +78,53 @@ function getDataType(data) {
   }
 }
 
-async function addOverviewAssetForFeature (feature, layerGroup, crossOrigin, errorCallback) {
+async function addOverviewAssetForFeature(feature, layerGroup, crossOrigin, errorCallback) {
+  if (!('bbox' in feature)) return;
+
   const { asset } = getOverviewAsset(feature.assets);
   if (isImageType(asset.type)) {
-    const lyr = await imageOverlay(asset.href, [[feature.bbox[1], feature.bbox[0]], [feature.bbox[3], feature.bbox[2]]], crossOrigin);
+    const lyr = await imageOverlay(
+      asset.href,
+      [
+        [feature.bbox[1], feature.bbox[0]],
+        [feature.bbox[3], feature.bbox[2]]
+      ],
+      crossOrigin
+    );
     if (lyr === null) {
-      if (errorCallback) errorCallback()
-      return
+      if (errorCallback) errorCallback();
+      return;
     }
-    layerGroup.addLayer(lyr)
-    lyr.on('error', () => {
-      layerGroup.removeLayer(lyr)
-      if (errorCallback) errorCallback()
-    })
+    layerGroup.addLayer(lyr);
+    lyr.on("error", () => {
+      layerGroup.removeLayer(lyr);
+      if (errorCallback) errorCallback();
+    });
   }
 }
 
-async function addThumbnailAssetForFeature (feature, layerGroup, crossOrigin, errorCallback) {
-  const { asset } = findAsset(feature.assets, 'thumbnail');
-  if (isImageType(asset.type)) { 
-    const lyr = await imageOverlay(asset.href, [[feature.bbox[1], feature.bbox[0]], [feature.bbox[3], feature.bbox[2]]], crossOrigin);
+async function addThumbnailAssetForFeature(feature, layerGroup, crossOrigin, errorCallback) {
+  if (!('bbox' in feature)) return;
+
+  const { asset } = findAsset(feature.assets, "thumbnail");
+  if (isImageType(asset.type)) {
+    const lyr = await imageOverlay(
+      asset.href,
+      [
+        [feature.bbox[1], feature.bbox[0]],
+        [feature.bbox[3], feature.bbox[2]]
+      ],
+      crossOrigin
+    );
     if (lyr === null) {
-      if (errorCallback) errorCallback()
-      return
+      if (errorCallback) errorCallback();
+      return;
     }
-    layerGroup.addLayer(lyr)
-    lyr.on('error', () => {
-      layerGroup.removeLayer(lyr)
-      if (errorCallback) errorCallback()
-    })
+    layerGroup.addLayer(lyr);
+    lyr.on("error", () => {
+      layerGroup.removeLayer(lyr);
+      if (errorCallback) errorCallback();
+    });
   }
 }
 
@@ -231,23 +250,21 @@ const stacLayer = async (data, options = {}) => {
     const lyr = L.geoJSON(data, options);
 
     data.features.forEach(f => {
-
       if (displayPreview) {
         // If we've got a thumnail asset add it
-        if (hasAsset(f.assets, "thumbnail")) { 
+        if (hasAsset(f.assets, "thumbnail")) {
           addThumbnailAssetForFeature(f, layerGroup, options.crossOrigin, () => {
             // If some reason it's broken try for an overview asset
             if (hasAsset(f.assets, "overview")) {
-              addOverviewAssetForFeature(f, layerGroup, options.crossOrigin)
+              addOverviewAssetForFeature(f, layerGroup, options.crossOrigin);
             }
-          })
+          });
         } else if (!hasAsset(f.assets, "thumbnail") && hasAsset(f.assets, "overview")) {
-            // If we don't have a thumbail let's try for an overview asset
-            addOverviewAssetForFeature(f, layerGroup, options.crossOrigin)
+          // If we don't have a thumbail let's try for an overview asset
+          addOverviewAssetForFeature(f, layerGroup, options.crossOrigin);
+        }
       }
-    }
-
-    })
+    });
     bindDataToClickEvent(lyr, e => {
       try {
         const { lat, lng } = e.latlng;
@@ -337,7 +354,7 @@ const stacLayer = async (data, options = {}) => {
             layerGroup.stac = { assets: [{ key, asset }], bands: asset?.["eo:bands"] };
             layerGroup.addLayer(overviewLayer);
             addedImagery = true;
-            if (debugLevel >= 1) console.log("[stac-layer] succesfully added overview layer");            
+            if (debugLevel >= 1) console.log("[stac-layer] succesfully added overview layer");
           }
         } else if (isAssetCOG(asset)) {
           if (preferTileLayer) {
@@ -381,7 +398,7 @@ const stacLayer = async (data, options = {}) => {
             bindDataToClickEvent(thumbLayer, data);
             layerGroup.addLayer(thumbLayer);
             addedImagery = true;
-            if (debugLevel >= 1) console.log("[stac-layer] succesfully added thumbnail layer");            
+            if (debugLevel >= 1) console.log("[stac-layer] succesfully added thumbnail layer");
           }
         }
       } catch (error) {
@@ -404,7 +421,7 @@ const stacLayer = async (data, options = {}) => {
             bindDataToClickEvent(previewLayer, data);
             layerGroup.addLayer(previewLayer);
             addedImagery = true;
-            if (debugLevel >= 1) console.log("[stac-layer] succesfully added preview layer");            
+            if (debugLevel >= 1) console.log("[stac-layer] succesfully added preview layer");
           }
         }
       } catch (error) {

--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,7 @@ function addOverviewAssetForFeature (feature, layerGroup, errorCallback) {
 }
 
 function addThumbnailAssetForFeature (feature, layerGroup, errorCallback) {
-  const { asset } = getAsset(feature.assets, 'thumbnail');
+  const { asset } = findAsset(feature.assets, 'thumbnail');
   if (isImageType(asset.type)) { 
     const lyr = L.imageOverlay(asset.href, [[feature.bbox[1], feature.bbox[0]], [feature.bbox[3], feature.bbox[2]]])
     layerGroup.addLayer(lyr)
@@ -98,6 +98,7 @@ function addThumbnailAssetForFeature (feature, layerGroup, errorCallback) {
       layerGroup.removeLayer(lyr)
       errorCallback()
     })
+  }
 }
 
 // relevant links:

--- a/src/test/item-collection/cogs_with_overview.html
+++ b/src/test/item-collection/cogs_with_overview.html
@@ -26,8 +26,11 @@
           attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
       }).addTo(map);
 
-
-      const url_to_stac_item = 'https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs/items?limit=10';
+      // has a broken thumbnail asset but functional overview asset
+      const url_to_stac_item = 'https://planetarycomputer.microsoft.com/api/stac/v1/search?bbox=125.727770,-29.514858,133.412707,-23.673395&collections=landsat-8-c2-l2&limit=5';
+      
+      // has a functional thumbnail asset
+      // const url_to_stac_item = 'https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs/items?limit=10'
 
       fetch(url_to_stac_item).then(res => res.json()).then(async item => {
         const lyr = await L.stacLayer(item, {

--- a/src/test/item-collection/cogs_with_overview_no_bbox.html
+++ b/src/test/item-collection/cogs_with_overview_no_bbox.html
@@ -27,10 +27,10 @@
       }).addTo(map);
 
       // has a broken thumbnail asset but functional overview asset
-      // const url_to_stac_item = 'https://planetarycomputer.microsoft.com/api/stac/v1/search?bbox=125.727770,-29.514858,133.412707,-23.673395&collections=landsat-8-c2-l2&limit=5';
+      const url_to_stac_item = 'https://planetarycomputer.microsoft.com/api/stac/v1/search?bbox=125.727770,-29.514858,133.412707,-23.673395&collections=landsat-8-c2-l2&limit=5';
       
       // has a functional thumbnail asset
-      const url_to_stac_item = 'https://tamn.snapplanet.io/search?bbox=125.727770,-29.514858,133.412707,-23.673395&collections=S2'
+      // const url_to_stac_item = 'https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs/items?limit=10'
 
       fetch(url_to_stac_item).then(res => res.json()).then(async item => {
         const lyr = await L.stacLayer(item, {

--- a/src/test/item-collection/sentinel2_cogs.html
+++ b/src/test/item-collection/sentinel2_cogs.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"/>
+    <style>
+      #map {
+        bottom: 0;
+        left: 0;
+        position: absolute;
+        right: 0;
+        top: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="map"></div>
+    <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
+    <script src="/index.js" type="module"></script>
+    <script type="module">
+      // initalize leaflet map
+      const map = L.map('map').setView([0, 0], 5);
+
+      // add OpenStreetMap basemap
+      L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+          attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+      }).addTo(map);
+
+
+      const url_to_stac_item = 'https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs/items?limit=10';
+
+      fetch(url_to_stac_item).then(res => res.json()).then(async item => {
+        const lyr = await L.stacLayer(item, {
+          debugLevel: 2,
+          displayPreview: true
+        });
+
+        lyr.addTo(map);
+
+        lyr.on('click', console.log);
+
+        map.fitBounds(lyr.getLayers()[0].getBounds());
+      });
+    </script>
+  </body>
+</html>

--- a/src/utils/image-overlay.js
+++ b/src/utils/image-overlay.js
@@ -4,17 +4,19 @@ import loadImage from "easy-image-loader";
 // pratically identical to L.imageOverlay
 // with the following exceptions:
 // (1) it is async and returns a promise
-// (2) rejects the promise if there is an issue loading the image
-// (3) rejects the promise if it takes more than 5 seconds for the image to load
+// (2) if there is any error, the returned promise resolves to null 
 export default async function imageOverlay(url, bounds, crossOrigin, options) {
-  const timeout = 5 * 1000; // 5 seconds
-  let img = null
   try {
-    img = await loadImage(url, { crossOrigin, timeout });
-  }
-  catch {
+    const timeout = 5 * 1000; // 5 seconds
+    let img = null;
+    try {
+      img = await loadImage(url, { crossOrigin, timeout });
+    } catch {
+      return null
+    }
+    const lyr = L.imageOverlay(img, bounds, options);
+    return lyr;
+  } catch {
     return null
   }
-  const lyr = L.imageOverlay(img, bounds, options);
-  return lyr;
 }

--- a/src/utils/image-overlay.js
+++ b/src/utils/image-overlay.js
@@ -8,7 +8,13 @@ import loadImage from "easy-image-loader";
 // (3) rejects the promise if it takes more than 5 seconds for the image to load
 export default async function imageOverlay(url, bounds, crossOrigin, options) {
   const timeout = 5 * 1000; // 5 seconds
-  const img = await loadImage(url, { crossOrigin, timeout });
+  let img = null
+  try {
+    img = await loadImage(url, { crossOrigin, timeout });
+  }
+  catch {
+    return null
+  }
   const lyr = L.imageOverlay(img, bounds, options);
   return lyr;
 }


### PR DESCRIPTION
This PR adds support for displaying thumbnail assets or overview assets of items within an ItemCollection when `displayPreview` option is true. 

When testing with the PlanetaryComputer endpoint I noticed that the thumbnail asset was present but broken, so I've added a fallback to trying for an overview asset in that case.

https://user-images.githubusercontent.com/6735870/163709146-c5618488-5bea-4d7c-8b64-47470e14254a.mp4


