### PR TITLE
Displaying a specified asset

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -334,7 +334,7 @@ const stacLayer = async (data, options = {}) => {
     // first, check if we're supposed to be showing a particular asset
     if (displayAssetId !== null) {
       const asset = assets[displayAssetId]
-      if (isAssetCOG(asset)) {
+      if (asset !== undefined && isAssetCOG(asset)) {
         const href = toAbsoluteHref(asset.href);
         try {
           const georasterLayer = await createGeoRasterLayer(href, options);

--- a/src/index.js
+++ b/src/index.js
@@ -481,7 +481,6 @@ const stacLayer = async (data, options = {}) => {
     // if we still haven't found a valid imagery layer yet, just add the first COG
     const cogs = Object.entries(assets).filter(entry => isAssetCOG(entry[1]));
     if (!addedImagery && cogs.length >= 1) {
-      console.log('adding a COG')
       if (debugLevel >= 1) console.log(`[stac-layer] defaulting to trying to display the first COG asset`);
       const [key, asset] = cogs[0];
       const href = toAbsoluteHref(asset.href);

--- a/src/test/stac-item/cogs/cog-selected-asset-object.html
+++ b/src/test/stac-item/cogs/cog-selected-asset-object.html
@@ -32,7 +32,7 @@
       fetch(url_to_stac_item).then(res => res.json()).then(async item => {
         const lyr = await L.stacLayer(item, { 
           debugLevel: 2,
-          assets: 'udm'
+          assets: [item.assets.udm]
         });
         console.log("lyr.stac:", lyr.stac);
         lyr.on('click', console.log);

--- a/src/test/stac-item/cogs/cog-selected-asset.html
+++ b/src/test/stac-item/cogs/cog-selected-asset.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css"/>
+    <style>
+      #map {
+        bottom: 0;
+        left: 0;
+        position: absolute;
+        right: 0;
+        top: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="map"></div>
+    <script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet.js"></script>
+    <script src="/index.js" type="module"></script>
+    <script type="module">
+      // initalize leaflet map
+      const map = L.map('map').setView([0, 0], 5);
+
+      // add OpenStreetMap basemap
+      L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+          attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+      }).addTo(map);
+
+
+      const url_to_stac_item = "https://raw.githubusercontent.com/cholmes/pdd-stac/beta2/disasters/hurricane-harvey/hurricane-harvey-0831/20170831_172754_101c/20170831_172754_101c.json";
+
+      fetch(url_to_stac_item).then(res => res.json()).then(async item => {
+        const lyr = await L.stacLayer(item, { 
+          debugLevel: 2,
+          displayAssetId: 'udm'
+        });
+        console.log("lyr.stac:", lyr.stac);
+        lyr.on('click', console.log);
+        lyr.addTo(map);
+        map.fitBounds(lyr.getBounds());
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This PR adds a new option called `displayAssetId` which when set looks for a COG and then displays it as a preference compared to some of the other assets. 
ATM it only works for COG assets but conceivably it could be extended to support other asset types.

