### PR TITLE
added bands option to stacLayer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,4 @@ build/
 # lock files
 pnpm-lock.yaml
 .pnpm-store/
+data/*.tif*

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The following options are supported:
 
 | **Option**                   | **Data Type** | **Default value**                          | **Description** |
 | ---------------------------- | ------------- | ------------------------------------------ |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `bands`                      | array of numbers | undefined | an array mapping the bands to the output bands. must be of length 3 or 4. |
 | `baseUrl`                    | string        | `href` of the `self` link in the STAC data | The base URL for relative links. Should be provided if the STAC data has no self link and links are not absolute, or you pass a STAC Asset only. |
 | `buildTileUrlTemplate`       | function      | undefined                                  | For server-side rendering of imagery. See the chapter [using a tiler](#using-a-tiler) and [buildTileUrlTemplate](#buildTileUrlTemplate) for details. |
 | `crossOrigin`                | string\|null  | undefined                                  | The value for the [`crossorigin` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin) that is set when loading images through the browser. |

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "build": "webpack",
     "dev": "concurrently \"WEBPACK_WATCH=true webpack\" \"npm run serve\"",
     "format": "npx prettier --arrow-parens=avoid --print-width=120 --trailing-comma=none --write src/*.js src/*/*.js",
-    "serve": "npx srvd --debug",
+    "test:files": "for f in $(find test | grep html); do echo \"http://localhost:8080/$f\"; done",
+    "serve": "npx srvd --debug --wait=Infinity",
     "test": "echo 'no automatic tests'",
     "tiler": "docker run --env-file=./.env --name titiler -p 8000:8000 --env PORT=8000 --rm -t developmentseed/titiler"
   },

--- a/src/utils/create-georaster-layer.js
+++ b/src/utils/create-georaster-layer.js
@@ -9,6 +9,11 @@ export default function createGeoRasterLayer(url, options) {
     // just in case
     if (options.debugLevel < 0) options.debugLevel = 0;
 
-    return new GeoRasterLayer({ georaster, ...options });
+    const layer = new GeoRasterLayer({ georaster, ...options });
+
+    // hack to force GeoRasterLayer to calculate statistics
+    if (options.calcStats) layer.calcStats = true;
+
+    return layer;
   });
 }

--- a/test/stac-item-asset/pdd/analytic-bands.html
+++ b/test/stac-item-asset/pdd/analytic-bands.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"/>
+    <style>
+      #map {
+        bottom: 0;
+        left: 0;
+        position: absolute;
+        right: 0;
+        top: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="map"></div>
+    <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
+    <script src="/dist/stac-layer.min.js" type="module"></script>
+    <script type="module">
+      // initalize leaflet map
+      const map = L.map('map').setView([0, 0], 5);
+
+      // add OpenStreetMap basemap
+      L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+          attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+      }).addTo(map);
+
+
+      const url_to_stac_item = "https://raw.githubusercontent.com/cholmes/pdd-stac/beta2/disasters/hurricane-harvey/hurricane-harvey-0831/20170831_172754_101c/20170831_172754_101c.json";
+
+      fetch(url_to_stac_item).then(res => res.json()).then(async feature => {
+        const asset = feature.assets.analytic;
+        console.log("asset:", asset);
+
+        const lyr = await L.stacLayer(asset, {
+          bbox: feature.bbox,
+          debugLevel: 2,
+          bands: [2, 1, 0],
+          resolution: 64
+         });
+
+        lyr.on('click', console.log);
+
+        lyr.addTo(map);
+
+        map.fitBounds(lyr.getBounds());
+      });
+    </script>
+  </body>
+</html>

--- a/test/stac-item-asset/pdd/one-band.html
+++ b/test/stac-item-asset/pdd/one-band.html
@@ -34,11 +34,8 @@
         console.log("asset:", asset);
 
         const lyr = await L.stacLayer(asset, {
-          // display only red band
-          pixelValuesToColorFn: ([r, g, b, a]) => {
-            const max = Math.pow(2, 15);
-            return `rgb(${(r / max) * 255},${(r / max) * 255},${(r / max) * 255})`;
-          },
+          // display only the first band (red band)
+          bands: [0, 0, 0],
           bbox: feature.bbox,
           debugLevel: 2,
          });

--- a/test/stac-item-asset/pdd/visual-bands-reversed.html
+++ b/test/stac-item-asset/pdd/visual-bands-reversed.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"/>
+    <style>
+      #map {
+        bottom: 0;
+        left: 0;
+        position: absolute;
+        right: 0;
+        top: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="map"></div>
+    <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
+    <script src="/dist/stac-layer.min.js" type="module"></script>
+    <script type="module">
+      // initalize leaflet map
+      const map = L.map('map').setView([0, 0], 5);
+
+      // add OpenStreetMap basemap
+      L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+          attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+      }).addTo(map);
+
+
+      const url_to_stac_item = "https://raw.githubusercontent.com/cholmes/pdd-stac/beta2/disasters/hurricane-harvey/hurricane-harvey-0831/20170831_172754_101c/20170831_172754_101c.json";
+
+      fetch(url_to_stac_item).then(res => res.json()).then(async feature => {
+        const asset = feature.assets.visual;
+
+        const lyr = await L.stacLayer(asset, {
+          bands: [2, 1, 0],
+          debugLevel: 2,
+          resolution: 256
+        });
+
+        lyr.on('click', console.log);
+
+        lyr.addTo(map);
+
+        map.fitBounds(lyr.getLayers()[0].getBounds());
+      });
+    </script>
+  </body>
+</html>

--- a/test/stac-item/cogs/cog-no-cors-overview.html
+++ b/test/stac-item/cogs/cog-no-cors-overview.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css"/>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css"/>
     <style>
       #map {
         bottom: 0;
@@ -15,7 +15,7 @@
   </head>
   <body>
     <div id="map"></div>
-    <script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet.js"></script>
+    <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
     <script src="/dist/stac-layer.min.js" type="module"></script>
     <script type="module">
       // initalize leaflet map


### PR DESCRIPTION
This Pull Request adds the bands option to stacLayer.  You can use it to re-map the bands to [R, G, B] or [R,G,B,A] bands of the rendered image for assets that are passed to GeoRasterLayer.  As a part of this, it will automatically stretch the bands to fit in the image color space (0-255), so you don't have to worry about 16-bit images.  The stretching uses the statistics that are dynamically calculated by GeoRasterLayer based on rendered pixels.

Example:
```js
// only visualize second band (index 1)
stacLayer(data, { bands: [1, 1, 1] })

// in image with [red, green, blue, nir] use [nir, green, blue]
stacLayer(data, { bands: [3, 1, 2] })
```

Open to thoughts and suggestions.

This PR is indeed hacky, requiring a few features of GeoRasterLayer that are not publicly documented.  This functionality might be added to GeoRasterLayer at some point, which would simplify the stac-layer code.