### PR TITLE
Pass item/collection correctly into buildTileUrlTemplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ const layer = await stacLayer(data, {
     href, // the url to the GeoTIFF
     asset, // the STAC Asset object
     key, // the key or name in the assets object that points to the particular asset
-    item, // the STAC item / feature
+    item, // the STAC Item or STAC Collection, if available
     bounds, // LatLngBounds of the STAC asset
     isCOG: true, // true if the asset is definitely a cloud-optimized GeoTIFF
     isVisual: true, // true when the asset's key is "visual" (case-insensitive)

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ const layer = await stacLayer(data, {
     href, // the url to the GeoTIFF
     asset, // the STAC Asset object
     key, // the key or name in the assets object that points to the particular asset
-    item, // the STAC Item or STAC Collection, if available
+    stac, // the STAC Item or STAC Collection, if available
     bounds, // LatLngBounds of the STAC asset
     isCOG: true, // true if the asset is definitely a cloud-optimized GeoTIFF
     isVisual: true, // true when the asset's key is "visual" (case-insensitive)

--- a/src/index.js
+++ b/src/index.js
@@ -313,7 +313,7 @@ const stacLayer = async (data, options = {}) => {
             url: href,
             asset,
             key,
-            item: asset,
+            item: data,
             bounds,
             isCOG,
             isVisual

--- a/src/index.js
+++ b/src/index.js
@@ -313,7 +313,7 @@ const stacLayer = async (data, options = {}) => {
             url: href,
             asset,
             key,
-            item: data,
+            stac: data,
             bounds,
             isCOG,
             isVisual
@@ -600,7 +600,7 @@ const stacLayer = async (data, options = {}) => {
               url: href,
               asset: data,
               key: null,
-              item: null,
+              stac: null,
               isCOG: MIME_TYPES.COG.includes(type),
               isVisual: null
             });


### PR DESCRIPTION
The item/collection is passed into buildTileUrlTemplate as item instead of the asset.