### PR TITLE
made tileLayer accept async buildTileUrlTemplate function

### DIFF
--- a/src/add.js
+++ b/src/add.js
@@ -64,7 +64,7 @@ export async function addTileLayer(asset, layerGroup, options) {
     const key = asset.getKey();
     const bounds = getBounds(asset, options);
     if (options.buildTileUrlTemplate) {
-      const tileUrlTemplate = options.buildTileUrlTemplate({
+      const tileUrlTemplate = await options.buildTileUrlTemplate({
         href,
         url: href,
         asset,

--- a/test/tilers/titiler/build-tile-url-template.html
+++ b/test/tilers/titiler/build-tile-url-template.html
@@ -30,7 +30,7 @@
       const url_to_stac_item = "https://www.planet.com/data/stac/disasters/hurricane-harvey/hurricane-harvey-0831/20170831_172754_101c/20170831_172754_101c.json";
 
       fetch(url_to_stac_item).then(res => res.json()).then(async feature => {
-        const buildTileUrlTemplate = ({ asset, href, item }) => {
+        const buildTileUrlTemplate = async ({ asset, href, item }) => {
           let bands = asset.findVisualBands();
           if (!bands) {
             return "https://tiles.rdnt.io/tiles/{z}/{x}/{y}@2x?url={url}";


### PR DESCRIPTION
This enables async function for the buildTileUrlTemplate option.

Will solve the issue related to [this.](https://github.com/radiantearth/stac-browser/issues/373)